### PR TITLE
spec file - add git to build requirements

### DIFF
--- a/pkg/rpm/nemea-modules-ng.spec.in
+++ b/pkg/rpm/nemea-modules-ng.spec.in
@@ -10,6 +10,7 @@ BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires: gcc >= 8
 BuildRequires: gcc-c++ >= 8
 BuildRequires: make
+BuildRequires: git
 BuildRequires: cmake >= 3.12
 BuildRequires: libtrap-devel
 BuildRequires: unirec >= 3.0.0


### PR DESCRIPTION
Git is needed to fetch 3rd party repositories