### PR TITLE
unirec-telemetry - add unirec-telemetry to the common object library

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,19 +1,22 @@
 add_subdirectory(external)
 
-# Create a common "object" library
-set(COMMON_SRC
+set(LOGGER_SRC
 	src/logger.cpp
 )
 
-add_library(common OBJECT ${COMMON_SRC})
-
-target_link_libraries(common
-	PUBLIC
-		spdlog::spdlog
+set(UNIREC_TELEMETRY_SRC
+	src/unirec-telemetry.cpp
 )
 
-target_include_directories(common
-	PUBLIC
-		include
-		spdlog::spdlog
+add_library(common OBJECT ${LOGGER_SRC} ${UNIREC_TELEMETRY_SRC})
+
+target_link_libraries(common PUBLIC
+	spdlog::spdlog
+	telemetry::telemetry
+	unirec::unirec++
+)
+
+target_include_directories(common PUBLIC
+	include
+	spdlog::spdlog
 )

--- a/common/include/unirec-telemetry.hpp
+++ b/common/include/unirec-telemetry.hpp
@@ -1,0 +1,47 @@
+/**
+ * @file
+ * @author Pavel Siska <siska@cesnet.cz>
+ * @brief Telemetry functions for Unirec interfaces.
+ *
+ * This file contains functions to retrieve telemetry data from Unirec interfaces.
+ *
+ * Example output format:
+ *
+ * @code
+ * receivedBytes = XXX
+ * receivedRecords = XXX
+ * missedRecords = XXX
+ * missed = XX %
+ * @endcode
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#include <telemetry.hpp>
+#include <unirec++/unirec.hpp>
+
+namespace nm {
+
+/**
+ * @brief Retrieves telemetry data for an input Unirec interface.
+ *
+ * This function retrieves and returns telemetry data for a given input Unirec interface.
+ *
+ * @param interface The input Unirec interface.
+ * @return telemetry::Content The telemetry data of the interface.
+ */
+telemetry::Content getInterfaceTelemetry(const Nemea::UnirecInputInterface& interface);
+
+/**
+ * @brief Retrieves telemetry data for a bidirectional Unirec interface.
+ *
+ * This function retrieves and returns telemetry data for a given bidirectional Unirec interface.
+ *
+ * @param interface The bidirectional Unirec interface.
+ * @return telemetry::Content The telemetry data of the interface.
+ */
+telemetry::Content getInterfaceTelemetry(const Nemea::UnirecBidirectionalInterface& interface);
+
+} // namespace nm

--- a/common/src/unirec-telemetry.cpp
+++ b/common/src/unirec-telemetry.cpp
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * @author Pavel Siska <siska@cesnet.cz>
+ * @brief
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "unirec-telemetry.hpp"
+
+namespace nm {
+
+static double getMissedPercentage(const Nemea::InputInteraceStats& stats)
+{
+	if (!stats.receivedRecords && !stats.missedRecords) {
+		return 0;
+	}
+
+	double fraction = static_cast<double>(stats.missedRecords)
+		/ static_cast<double>(stats.receivedRecords + stats.missedRecords);
+
+	const int fractionToPercentage = 100;
+	return fraction * fractionToPercentage;
+}
+
+static telemetry::Content createInterfaceTelemetry(const Nemea::InputInteraceStats& stats)
+{
+	telemetry::Dict dict;
+	dict["receivedBytes"] = stats.receivedBytes;
+	dict["receivedRecords"] = stats.receivedRecords;
+	dict["missedRecords"] = stats.missedRecords;
+	dict["missed"] = telemetry::ScalarWithUnit(getMissedPercentage(stats), "%");
+	return dict;
+}
+
+telemetry::Content getInterfaceTelemetry(const Nemea::UnirecBidirectionalInterface& interface)
+{
+	const auto stats = interface.getInputInterfaceStats();
+	return createInterfaceTelemetry(stats);
+}
+
+telemetry::Content getInterfaceTelemetry(const Nemea::UnirecInputInterface& interface)
+{
+	const auto stats = interface.getInputInterfaceStats();
+	return createInterfaceTelemetry(stats);
+}
+
+} // namespace nm


### PR DESCRIPTION
This commit introduces a unirec-telemetry (part of common library) which provides functions to retrieve telemetry data from Unirec interfaces.

The telemetry data includes:
- receivedBytes
- receivedRecords
- missedRecords
- missed percentage