### PR TITLE
github-ci - remove fedora40 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           osArray+=("rockylinux:9")
           osArray+=("oraclelinux:8")
           osArray+=("oraclelinux:9")
-          osArray+=("fedora:40")
           osArray=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${osArray[@]}")
           echo "Updated os list: $osArray"
           echo "os=$osArray" >> $GITHUB_OUTPUT


### PR DESCRIPTION
fedora40 is obsolete